### PR TITLE
set $ssl in Database constructor (missing)

### DIFF
--- a/src/Dabble/Database.php
+++ b/src/Dabble/Database.php
@@ -64,6 +64,7 @@ class Database
         $this->charset  = $charset;
         $this->port     = $port;
         $this->socket   = $socket;
+        $this->ssl      = $ssl;
         $this->cacert   = $cacert;
         $this->clientcert = $clientcert;
         $this->clientkey = $clientkey;


### PR DESCRIPTION
SSL doesn't trigger by default because the constructor doesn't actually set the `$ssl` property, so it's always `null`.